### PR TITLE
Update for the Hadoop pig barclamp. Fix JAVA_HOME and the pig package name (changed in the 4.x CDH/CM release). [1/4]

### DIFF
--- a/chef/cookbooks/pig/attributes/pig-properties.rb
+++ b/chef/cookbooks/pig/attributes/pig-properties.rb
@@ -24,7 +24,7 @@
 #######################################################################
 
 # Pig needs java home (/usr/bin/pig).
-default[:pig][:java_home] = "/usr/java/jdk1.6.0_27/jre"
+default[:pig][:java_home] = "/usr/java/jdk1.6.0_31/jre"
 
 # log4jconf log4j configuration file.
 default[:pig][:log4jconf] = "./conf/log4j.properties"

--- a/chef/cookbooks/pig/recipes/default.rb
+++ b/chef/cookbooks/pig/recipes/default.rb
@@ -29,7 +29,7 @@ Chef::Log.info("BEGIN pig:default") if debug
 env_filter = " AND environment:#{node[:pig][:config][:environment]}"
 
 # Install the hadoop base package.
-package "hadoop-pig" do
+package "pig" do
   action :install
 end
 

--- a/chef/data_bags/crowbar/bc-template-pig.json
+++ b/chef/data_bags/crowbar/bc-template-pig.json
@@ -4,7 +4,7 @@
   "attributes": {
     "pig": {
       "debug": true,
-      "java_home": "/usr/java/jdk1.6.0_27/jre",
+      "java_home": "/usr/java/jdk1.6.0_31/jre",
       "log4jconf": "./conf/log4j.properties",
       "brief": "false",
       "cluster": "",

--- a/crowbar_framework/app/models/pig_service.rb
+++ b/crowbar_framework/app/models/pig_service.rb
@@ -35,7 +35,7 @@ class PigService < ServiceObject
     nodes.delete_if { |n| n.nil? }
     
     # Find all hadoop edge nodes.
-    edge_nodes = nodes.find_all { |n| n.role? "hadoop-edgenode" }
+    edge_nodes = nodes.find_all { |n| n.role? "hadoop-edgenode" or n.role? "clouderamanager-edgenode" }
     edge_fqdns = Array.new
     edge_nodes.each { |x|
       next if x.nil?


### PR DESCRIPTION
Update for the Hadoop pig barclamp. Fix JAVA_HOME and the pig package name (changed in the 4.x CDH/CM release).

 chef/cookbooks/pig/attributes/pig-properties.rb |    2 +-
 chef/cookbooks/pig/recipes/default.rb           |    2 +-
 chef/data_bags/crowbar/bc-template-pig.json     |    2 +-
 crowbar_framework/app/models/pig_service.rb     |    2 +-
 4 files changed, 4 insertions(+), 4 deletions(-)
