### PR TITLE
Add os_support stanzas to selected barclamps. [9/12]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -23,6 +23,9 @@ barclamp:
     - clouderamanager
   member:
     - apachehadoop
+  os_support:
+    - redhat-6.2
+    - centos-6.2
 
 crowbar:
   layout: 2


### PR DESCRIPTION
This pull request adds os_support stanzas to various barclamps to
allow the dev tool to infer the proper OS for a given build.

 crowbar.yml |    3 +++
 1 file changed, 3 insertions(+)

Crowbar-Pull-ID: 18a9548803fe8236bd2918dcca092fdf4ffa73be

Crowbar-Release: development
