### PR TITLE
Added UI pulldown to enable/disable debug messages [1/1]

### DIFF
--- a/chef/cookbooks/pig/attributes/default.rb
+++ b/chef/cookbooks/pig/attributes/default.rb
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Author: Paul Webster
-#
 
 #######################################################################
 # Crowbar barclamp configuration parameters.

--- a/chef/cookbooks/pig/attributes/pig-properties.rb
+++ b/chef/cookbooks/pig/attributes/pig-properties.rb
@@ -16,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Author: Paul Webster
-#
 
 #######################################################################
 # Site Specific PIG settings (/etc/pig/conf/pig-properties).

--- a/chef/cookbooks/pig/recipes/default.rb
+++ b/chef/cookbooks/pig/recipes/default.rb
@@ -16,11 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Author: Paul Webster
-#
 
 #######################################################################
-# Begin recipe transactions
+# Begin recipe
 #######################################################################
 debug = node[:pig][:debug]
 Chef::Log.info("BEGIN pig:default") if debug
@@ -41,7 +39,7 @@ template "/etc/pig/conf/pig.properties" do
   source "pig-properties.erb"
 end
 
-# Update the pig startup script (Need to include JAVA_HOME).
+# Update the pig startup script (Need to set JAVA_HOME).
 template "/usr/bin/pig" do
   owner "root"
   group "root"
@@ -50,6 +48,6 @@ template "/usr/bin/pig" do
 end
 
 #######################################################################
-# End of recipe transactions
+# End of recipe
 #######################################################################
 Chef::Log.info("END pig:default") if debug

--- a/chef/data_bags/crowbar/bc-template-pig.json
+++ b/chef/data_bags/crowbar/bc-template-pig.json
@@ -3,7 +3,7 @@
   "description": "Platform for analyzing large data sets that consists of a high-level language for expressing data algorithms.",
   "attributes": {
     "pig": {
-      "debug": true,
+      "debug": false,
       "java_home": "/usr/java/jdk1.6.0_31/jre",
       "log4jconf": "./conf/log4j.properties",
       "brief": "false",

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -36,6 +36,9 @@ locale_additions:
       pig:
         edit_attributes:
           attributes: Attributes
+          barclamp_settings: Barclamp
+          debug: Log Debug Messages
+          pig_settings: Pig
           java_home: Java Home
           log4jconf: Log4j Configuration File
           brief: Brief Logging Mode

--- a/crowbar_framework/app/views/barclamp/pig/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/pig/_edit_attributes.html.haml
@@ -6,6 +6,18 @@
   %div.container
 
     %p
+    %br
+    %strong= t('.barclamp_settings')
+
+    %p
+      %label{ :for => :debug }= t('.debug')
+      = select_tag :debug, options_for_select([['false', false],['true', true]], @proposal.raw_data['attributes'][@proposal.barclamp]["debug"]), :onchange => "update_value('debug', 'debug', 'boolean')"
+
+    %p
+    %br
+    %strong= t('.pig_settings')
+
+    %p
       %label{ :for => :java_home }= t('.java_home')
       %input#java_home{:type => "text", :name => "java_home", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["java_home"], :onchange => "update_value('java_home', 'java_home', 'string')"}
 


### PR DESCRIPTION
Added UI pulldown to enable/disable debug messages

 chef/cookbooks/pig/attributes/default.rb           |    2 --
 chef/cookbooks/pig/attributes/pig-properties.rb    |    2 --
 chef/cookbooks/pig/recipes/default.rb              |    8 +++-----
 chef/data_bags/crowbar/bc-template-pig.json        |    2 +-
 crowbar.yml                                        |    3 +++
 .../views/barclamp/pig/_edit_attributes.html.haml  |   12 ++++++++++++
 6 files changed, 19 insertions(+), 10 deletions(-)

Crowbar-Pull-ID: e56d13be5d693ae73ee9bb7955a54120c3867d42

Crowbar-Release: fred
